### PR TITLE
Make delegate protocols be class-only

### DIFF
--- a/SSSpinnerButton/SpinerShapes/SpinnerAnimationDelegate/SpinnerAnimationDelegate.swift
+++ b/SSSpinnerButton/SpinerShapes/SpinnerAnimationDelegate/SpinnerAnimationDelegate.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 /// 
-protocol SSSpinnerAnimationDelegate {
+protocol SSSpinnerAnimationDelegate: AnyObject {
     
     /// setup spinner layer
     ///


### PR DESCRIPTION
Hi,

This PR makes the `SSSpinnerAnimationDelegate` protocol be class-only because delegates are always weakly-referenced.